### PR TITLE
Send 2D embeddings of 20newsgroup dataset through the /newsgroups endpoint

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,6 @@
+# ------ Server -------
 fastapi==0.89.1
 uvicorn[standard]==0.20.0
+
+# ----- ML ------
+datasets===2.9.0

--- a/backend/src/crud/newsgroups.py
+++ b/backend/src/crud/newsgroups.py
@@ -1,4 +1,6 @@
+from datasets import load_dataset
+
 async def get_all_embeddings():
-    
-    
-    return ""
+    dataset = load_dataset("fscheffczyk/2D_20newsgroup_embeddings", split="train")
+    json_data = dataset.to_dict()
+    return json_data

--- a/backend/src/crud/newsgroups.py
+++ b/backend/src/crud/newsgroups.py
@@ -1,0 +1,4 @@
+async def get_all_embeddings():
+    
+    
+    return ""

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,6 +1,8 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from src.routes import newsgroups
+
 app = FastAPI()
 
 # --- Middleware --- 
@@ -11,6 +13,8 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+app.include_router(newsgroups.router)
 
 @app.get("/")
 def home():

--- a/backend/src/routes/newsgroups.py
+++ b/backend/src/routes/newsgroups.py
@@ -1,0 +1,11 @@
+from fastapi import APIRouter, Depends, HTTPException
+
+import src.crud.newsgroups as crud
+
+router = APIRouter()
+
+@router.get(
+    "/newsgroups",
+)
+async def get_all_embeddings():
+    return await crud.get_all_embeddings()


### PR DESCRIPTION
Fetching the dataset from Huggingface Hub and make it available through the `/newsgroups` endpoint.